### PR TITLE
feat: separate OAuth tokens for Nauvoo and Ring Station

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Keep PRs under 300 lines. One logical change per PR.
 |----------|---------|---------|
 | `OBSIDIAN_DOCS_DIR` | _(required)_ | Path to Ring Station markdown files |
 | `GOOGLE_CLIENT_SECRETS` | `~/Keys/client_secrets.json` | OAuth client secrets |
-| `GOOGLE_TOKEN_FILE` | `~/ObsidianNotes/.../token.json` | OAuth token |
+| `GOOGLE_TOKEN_FILE` | `~/.config/nauvoo/token.json` | OAuth token |
 | `NAUVOO_POLL_INTERVAL` | `30` | Polling interval in seconds |
 | `LOG_LEVEL` | `INFO` | Logging verbosity |
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,6 @@ uv run nauvoo
 |----------|---------|---------|
 | `OBSIDIAN_DOCS_DIR` | _(required)_ | Directory of Ring Station markdown files |
 | `GOOGLE_CLIENT_SECRETS` | `~/Keys/client_secrets.json` | OAuth client secrets |
-| `GOOGLE_TOKEN_FILE` | `~/ObsidianNotes/.../token.json` | OAuth token |
+| `GOOGLE_TOKEN_FILE` | `~/.config/nauvoo/token.json` | OAuth token |
 | `NAUVOO_POLL_INTERVAL` | `30` | Polling interval in seconds |
 | `LOG_LEVEL` | `INFO` | Logging verbosity |

--- a/bin/run-daemon.sh
+++ b/bin/run-daemon.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export OBSIDIAN_DOCS_DIR="$HOME/ObsidianNotes/Work/16-Google-Docs"
+export GOOGLE_CLIENT_SECRETS="$HOME/Keys/client_secrets.json"
+export GOOGLE_TOKEN_FILE="$HOME/.config/nauvoo/token.json"
+export NAUVOO_POLL_INTERVAL=30
+export LOG_LEVEL=INFO
+
+cd /Users/poconnor/nauvoo
+exec /opt/homebrew/bin/uv run nauvoo

--- a/docs/plans/2026-03-07-separate-oauth-tokens-design.md
+++ b/docs/plans/2026-03-07-separate-oauth-tokens-design.md
@@ -1,0 +1,54 @@
+# Separate OAuth Tokens for Nauvoo and Ring Station
+
+**Date**: 2026-03-07
+**Status**: Accepted
+
+## Problem
+
+Nauvoo and Ring Station both default their `DEFAULT_TOKEN_FILE` to the same path:
+
+```
+~/ObsidianNotes/Work/02-Technical/Code/GoogleDataExtraction/credentials/token.json
+```
+
+Each project requests different Google OAuth scopes:
+
+| Project | Scopes |
+|---------|--------|
+| Nauvoo | `drive` (read+write) |
+| Ring Station | `calendar.readonly`, `documents.readonly`, `gmail.readonly`, `drive.readonly` |
+
+Whichever project authenticates last overwrites the token, breaking the other project's required scopes.
+
+## Decision
+
+Give each project its own token file using XDG-style paths:
+
+- **Nauvoo**: `~/.config/nauvoo/token.json`
+- **Ring Station**: `~/.config/ring-station/token.json`
+
+The `GOOGLE_TOKEN_FILE` env var override continues to work in both projects. The shared `client_secrets.json` at `~/Keys/client_secrets.json` remains unchanged — it's the OAuth app identity, not user-specific token state.
+
+## Alternatives Considered
+
+1. **Named tokens under `~/Keys/`** — Rejected. Mixes ephemeral OAuth tokens with static client secrets.
+2. **Shared auth library** — Rejected. Over-engineering for two projects with ~10 lines of auth code each.
+
+## Changes
+
+### Nauvoo
+
+1. `daemon.py` — Change `DEFAULT_TOKEN_FILE` to `~/.config/nauvoo/token.json`
+2. `google_auth.py` — Add `_check_scopes()` method (matches Ring Station's implementation). Raises `ValueError` with actionable message if token is missing required scopes.
+3. `README.md`, `CONTRIBUTING.md` — Update default token path in env var tables.
+
+### Ring Station
+
+1. `daemon.py` — Change `DEFAULT_TOKEN_FILE` to `~/.config/ring-station/token.json`
+2. `README.md`, `CONTRIBUTING.md`, `CLAUDE.md` — Update default token path in env var tables.
+
+## Migration
+
+1. Delete the old shared token at `~/ObsidianNotes/Work/02-Technical/Code/GoogleDataExtraction/credentials/token.json`
+2. Run each project — each triggers OAuth re-auth and writes its token to the new XDG path
+3. No data loss risk — tokens are ephemeral and auto-regenerated

--- a/docs/plans/2026-03-07-separate-oauth-tokens-impl.md
+++ b/docs/plans/2026-03-07-separate-oauth-tokens-impl.md
@@ -1,0 +1,393 @@
+# Separate OAuth Tokens Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Give Nauvoo and Ring Station separate OAuth token files so they stop overwriting each other's scopes.
+
+**Architecture:** Change the default token path constant in each project's daemon.py to an XDG-style path (`~/.config/<project>/token.json`). Add scope-checking to Nauvoo's GoogleAuthAdapter to match Ring Station's defensive guard. Update docs.
+
+**Tech Stack:** Python, google-auth, google-auth-oauthlib
+
+---
+
+### Task 1: Add scope checking to Nauvoo's GoogleAuthAdapter
+
+**Files:**
+- Test: `tests/unit/test_google_auth.py` (create)
+- Modify: `src/nauvoo/adapters/driven/google_auth.py`
+
+**Step 1: Write the failing tests**
+
+Create `tests/unit/test_google_auth.py`:
+
+```python
+"""Tests for GoogleAuthAdapter."""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_google_auth():
+    """Stub google.auth and google_auth_oauthlib so get_credentials() can run."""
+    mock_google = MagicMock()
+    mock_oauthlib = MagicMock()
+    modules = {
+        "google": mock_google,
+        "google.auth": mock_google.auth,
+        "google.auth.transport": mock_google.auth.transport,
+        "google.auth.transport.requests": mock_google.auth.transport.requests,
+        "google.oauth2": mock_google.oauth2,
+        "google.oauth2.credentials": mock_google.oauth2.credentials,
+        "google_auth_oauthlib": mock_oauthlib,
+        "google_auth_oauthlib.flow": mock_oauthlib.flow,
+    }
+    with patch.dict(sys.modules, modules):
+        sys.modules.pop("nauvoo.adapters.driven.google_auth", None)
+        from nauvoo.adapters.driven.google_auth import GoogleAuthAdapter
+
+        yield GoogleAuthAdapter
+
+
+class TestScopeChecking:
+    def test_raises_if_token_missing_scopes(self, mock_google_auth, tmp_path):
+        token_file = tmp_path / "token.json"
+        token_file.write_text(
+            json.dumps({"scopes": ["https://www.googleapis.com/auth/drive.readonly"]})
+        )
+
+        adapter = mock_google_auth(
+            client_secrets_file=tmp_path / "secrets.json",
+            token_file=token_file,
+            scopes=["https://www.googleapis.com/auth/drive"],
+        )
+
+        with pytest.raises(ValueError, match="missing required scopes"):
+            adapter.get_credentials()
+
+    def test_passes_when_all_scopes_present(self, mock_google_auth, tmp_path):
+        token_file = tmp_path / "token.json"
+        token_file.write_text(
+            json.dumps({"scopes": ["https://www.googleapis.com/auth/drive"]})
+        )
+
+        adapter = mock_google_auth(
+            client_secrets_file=tmp_path / "secrets.json",
+            token_file=token_file,
+            scopes=["https://www.googleapis.com/auth/drive"],
+        )
+
+        # Should not raise — scopes match
+        adapter.get_credentials()
+
+    def test_raises_file_not_found_when_no_secrets(self, mock_google_auth, tmp_path):
+        adapter = mock_google_auth(
+            client_secrets_file=tmp_path / "nonexistent_secrets.json",
+            token_file=tmp_path / "nonexistent_token.json",
+            scopes=["https://www.googleapis.com/auth/drive"],
+        )
+
+        with pytest.raises(FileNotFoundError):
+            adapter.get_credentials()
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/poconnor/nauvoo && uv run pytest tests/unit/test_google_auth.py -v`
+Expected: FAIL — `_check_scopes` does not exist, `FileNotFoundError` not raised.
+
+**Step 3: Add `_check_scopes()` and `FileNotFoundError` guard to GoogleAuthAdapter**
+
+Modify `src/nauvoo/adapters/driven/google_auth.py` to match this:
+
+```python
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleAuthAdapter:
+    def __init__(
+        self,
+        client_secrets_file: Path,
+        token_file: Path,
+        scopes: list[str],
+    ) -> None:
+        self._client_secrets_file = Path(client_secrets_file)
+        self._token_file = Path(token_file)
+        self._scopes = scopes
+
+    def get_credentials(self):
+        from google.auth.transport.requests import Request
+        from google.oauth2.credentials import Credentials
+        from google_auth_oauthlib.flow import InstalledAppFlow
+
+        creds = None
+        if self._token_file.exists():
+            has_scopes, missing = self._check_scopes()
+            if not has_scopes:
+                raise ValueError(
+                    f"Token missing required scopes: {missing}. "
+                    f"Delete {self._token_file} and re-run to authorize."
+                )
+            creds = Credentials.from_authorized_user_file(
+                str(self._token_file), self._scopes
+            )
+
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+                logger.info("Google credentials refreshed")
+            else:
+                if not self._client_secrets_file.exists():
+                    raise FileNotFoundError(
+                        f"OAuth client secrets not found at {self._client_secrets_file}"
+                    )
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    str(self._client_secrets_file), self._scopes
+                )
+                creds = flow.run_local_server(port=0)
+                logger.info("Google OAuth flow completed")
+
+            self._token_file.parent.mkdir(parents=True, exist_ok=True)
+            self._token_file.write_text(creds.to_json())
+
+        return creds
+
+    def _check_scopes(self) -> tuple[bool, set[str]]:
+        """Check if token has all required scopes."""
+        try:
+            token_data = json.loads(self._token_file.read_text())
+            granted = set(token_data.get("scopes", []))
+            required = set(self._scopes)
+            missing = required - granted
+            return len(missing) == 0, missing
+        except (json.JSONDecodeError, OSError):
+            return False, set(self._scopes)
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/poconnor/nauvoo && uv run pytest tests/unit/test_google_auth.py -v`
+Expected: All 3 tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/unit/test_google_auth.py src/nauvoo/adapters/driven/google_auth.py
+git commit -m "feat: add scope checking to Nauvoo GoogleAuthAdapter
+
+Co-Authored-By: Peter O'Connor <poconnor@stackoverflow.com>
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Change Nauvoo default token path to XDG
+
+**Files:**
+- Modify: `src/nauvoo/daemon.py:27-36`
+
+**Step 1: Update the DEFAULT_TOKEN_FILE constant**
+
+In `src/nauvoo/daemon.py`, replace lines 27-36:
+
+```python
+# Before:
+DEFAULT_TOKEN_FILE = (
+    Path.home()
+    / "ObsidianNotes"
+    / "Work"
+    / "02-Technical"
+    / "Code"
+    / "GoogleDataExtraction"
+    / "credentials"
+    / "token.json"
+)
+
+# After:
+DEFAULT_TOKEN_FILE = Path.home() / ".config" / "nauvoo" / "token.json"
+```
+
+Also update the docstring at line 11:
+
+```python
+# Before:
+#     GOOGLE_TOKEN_FILE: Path to OAuth token.json (default: ~/ObsidianNotes/Work/.../token.json)
+# After:
+#     GOOGLE_TOKEN_FILE: Path to OAuth token.json (default: ~/.config/nauvoo/token.json)
+```
+
+**Step 2: Run the full Nauvoo test suite**
+
+Run: `cd /Users/poconnor/nauvoo && uv run pytest tests/ -v`
+Expected: All tests PASS (no test depends on the default path constant).
+
+**Step 3: Commit**
+
+```bash
+git add src/nauvoo/daemon.py
+git commit -m "feat: change Nauvoo default token path to ~/.config/nauvoo/token.json
+
+Co-Authored-By: Peter O'Connor <poconnor@stackoverflow.com>
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Update Nauvoo docs
+
+**Files:**
+- Modify: `README.md:71`
+- Modify: `CONTRIBUTING.md:128`
+
+**Step 1: Update README.md env var table**
+
+Change line 71 from:
+```
+| `GOOGLE_TOKEN_FILE` | `~/ObsidianNotes/.../token.json` | OAuth token |
+```
+To:
+```
+| `GOOGLE_TOKEN_FILE` | `~/.config/nauvoo/token.json` | OAuth token |
+```
+
+**Step 2: Update CONTRIBUTING.md env var table**
+
+Change line 128 from:
+```
+| `GOOGLE_TOKEN_FILE` | `~/ObsidianNotes/.../token.json` | OAuth token |
+```
+To:
+```
+| `GOOGLE_TOKEN_FILE` | `~/.config/nauvoo/token.json` | OAuth token |
+```
+
+**Step 3: Commit**
+
+```bash
+git add README.md CONTRIBUTING.md
+git commit -m "docs: update Nauvoo token path in README and CONTRIBUTING
+
+Co-Authored-By: Peter O'Connor <poconnor@stackoverflow.com>
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Change Ring Station default token path to XDG
+
+**Files:**
+- Modify: `/Users/poconnor/ringstation/src/ring_station/daemon.py:30-39`
+
+**Step 1: Update the DEFAULT_TOKEN_FILE constant**
+
+In `/Users/poconnor/ringstation/src/ring_station/daemon.py`, replace lines 30-39:
+
+```python
+# Before:
+DEFAULT_TOKEN_FILE = (
+    Path.home()
+    / "ObsidianNotes"
+    / "Work"
+    / "02-Technical"
+    / "Code"
+    / "GoogleDataExtraction"
+    / "credentials"
+    / "token.json"
+)
+
+# After:
+DEFAULT_TOKEN_FILE = Path.home() / ".config" / "ring-station" / "token.json"
+```
+
+**Step 2: Run the full Ring Station test suite**
+
+Run: `cd /Users/poconnor/ringstation && uv run pytest tests/ -v`
+Expected: All tests PASS.
+
+**Step 3: Commit**
+
+```bash
+cd /Users/poconnor/ringstation
+git checkout -b feat/separate-oauth-tokens
+git add src/ring_station/daemon.py
+git commit -m "feat: change Ring Station default token path to ~/.config/ring-station/token.json
+
+Co-Authored-By: Peter O'Connor <poconnor@stackoverflow.com>
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Update Ring Station docs
+
+**Files:**
+- Modify: `/Users/poconnor/ringstation/README.md:415`
+- Modify: `/Users/poconnor/ringstation/CONTRIBUTING.md:161`
+- Modify: `/Users/poconnor/ringstation/CLAUDE.md:73`
+
+**Step 1: Update README.md env var table**
+
+Change line 415 from:
+```
+| `GOOGLE_TOKEN_FILE` | `.../GoogleDataExtraction/credentials/token.json` | OAuth token cache |
+```
+To:
+```
+| `GOOGLE_TOKEN_FILE` | `~/.config/ring-station/token.json` | OAuth token cache |
+```
+
+**Step 2: Update CONTRIBUTING.md env var table**
+
+Change line 161 from:
+```
+| `GOOGLE_TOKEN_FILE` | `~/ObsidianNotes/.../token.json` | OAuth token |
+```
+To:
+```
+| `GOOGLE_TOKEN_FILE` | `~/.config/ring-station/token.json` | OAuth token |
+```
+
+**Step 3: Update CLAUDE.md env var table**
+
+Change line 73 from:
+```
+| GOOGLE_TOKEN_FILE | .../GoogleDataExtraction/credentials/token.json | OAuth token cache |
+```
+To:
+```
+| GOOGLE_TOKEN_FILE | ~/.config/ring-station/token.json | OAuth token cache |
+```
+
+**Step 4: Commit**
+
+```bash
+cd /Users/poconnor/ringstation
+git add README.md CONTRIBUTING.md CLAUDE.md
+git commit -m "docs: update Ring Station token path in README, CONTRIBUTING, and CLAUDE.md
+
+Co-Authored-By: Peter O'Connor <poconnor@stackoverflow.com>
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Delete the old shared token file
+
+**Step 1: Remove the old token**
+
+```bash
+rm ~/ObsidianNotes/Work/02-Technical/Code/GoogleDataExtraction/credentials/token.json
+```
+
+This forces both projects to re-authenticate on next run, writing their tokens to the new XDG paths.

--- a/src/nauvoo/adapters/driven/google_auth.py
+++ b/src/nauvoo/adapters/driven/google_auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 
@@ -13,8 +14,8 @@ class GoogleAuthAdapter:
         token_file: Path,
         scopes: list[str],
     ) -> None:
-        self._client_secrets_file = client_secrets_file
-        self._token_file = token_file
+        self._client_secrets_file = Path(client_secrets_file)
+        self._token_file = Path(token_file)
         self._scopes = scopes
 
     def get_credentials(self):
@@ -24,6 +25,12 @@ class GoogleAuthAdapter:
 
         creds = None
         if self._token_file.exists():
+            has_scopes, missing = self._check_scopes()
+            if not has_scopes:
+                raise ValueError(
+                    f"Token missing required scopes: {missing}. "
+                    f"Delete {self._token_file} and re-run to authorize."
+                )
             creds = Credentials.from_authorized_user_file(
                 str(self._token_file), self._scopes
             )
@@ -33,6 +40,10 @@ class GoogleAuthAdapter:
                 creds.refresh(Request())
                 logger.info("Google credentials refreshed")
             else:
+                if not self._client_secrets_file.exists():
+                    raise FileNotFoundError(
+                        f"OAuth client secrets not found at {self._client_secrets_file}"
+                    )
                 flow = InstalledAppFlow.from_client_secrets_file(
                     str(self._client_secrets_file), self._scopes
                 )
@@ -43,3 +54,14 @@ class GoogleAuthAdapter:
             self._token_file.write_text(creds.to_json())
 
         return creds
+
+    def _check_scopes(self) -> tuple[bool, set[str]]:
+        """Check if token has all required scopes."""
+        try:
+            token_data = json.loads(self._token_file.read_text())
+            granted = set(token_data.get("scopes", []))
+            required = set(self._scopes)
+            missing = required - granted
+            return len(missing) == 0, missing
+        except (json.JSONDecodeError, OSError):
+            return False, set(self._scopes)

--- a/src/nauvoo/adapters/driven/google_drive_writer.py
+++ b/src/nauvoo/adapters/driven/google_drive_writer.py
@@ -12,8 +12,7 @@ class GoogleDriveWriterAdapter(DriveWriterPort):
     def post_reply(self, file_id: str, comment_id: str, body: str) -> str:
         """Post a reply to an existing Drive comment. Returns the new reply ID."""
         result = (
-            self._drive.comments()
-            .replies()
+            self._drive.replies()
             .create(
                 fileId=file_id,
                 commentId=comment_id,

--- a/src/nauvoo/daemon.py
+++ b/src/nauvoo/daemon.py
@@ -8,7 +8,7 @@ Usage:
 Environment variables:
     OBSIDIAN_DOCS_DIR: Path to Obsidian vault directory containing Ring Station docs (REQUIRED)
     GOOGLE_CLIENT_SECRETS: Path to OAuth client_secrets.json (default: ~/Keys/client_secrets.json)
-    GOOGLE_TOKEN_FILE: Path to OAuth token.json (default: ~/ObsidianNotes/Work/.../token.json)
+    GOOGLE_TOKEN_FILE: Path to OAuth token.json (default: ~/.config/nauvoo/token.json)
     NAUVOO_POLL_INTERVAL: Poll interval in seconds (default: 30)
     LOG_LEVEL: Logging verbosity (default: INFO)
 """
@@ -24,16 +24,7 @@ from pathlib import Path
 logger = logging.getLogger("nauvoo.daemon")
 
 DEFAULT_CLIENT_SECRETS = Path.home() / "Keys" / "client_secrets.json"
-DEFAULT_TOKEN_FILE = (
-    Path.home()
-    / "ObsidianNotes"
-    / "Work"
-    / "02-Technical"
-    / "Code"
-    / "GoogleDataExtraction"
-    / "credentials"
-    / "token.json"
-)
+DEFAULT_TOKEN_FILE = Path.home() / ".config" / "nauvoo" / "token.json"
 
 GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/drive",  # read + write for comments/replies

--- a/tests/unit/test_google_auth.py
+++ b/tests/unit/test_google_auth.py
@@ -1,0 +1,73 @@
+"""Tests for GoogleAuthAdapter."""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_google_auth():
+    """Stub google.auth and google_auth_oauthlib so get_credentials() can run."""
+    mock_google = MagicMock()
+    mock_oauthlib = MagicMock()
+    modules = {
+        "google": mock_google,
+        "google.auth": mock_google.auth,
+        "google.auth.transport": mock_google.auth.transport,
+        "google.auth.transport.requests": mock_google.auth.transport.requests,
+        "google.oauth2": mock_google.oauth2,
+        "google.oauth2.credentials": mock_google.oauth2.credentials,
+        "google_auth_oauthlib": mock_oauthlib,
+        "google_auth_oauthlib.flow": mock_oauthlib.flow,
+    }
+    with patch.dict(sys.modules, modules):
+        sys.modules.pop("nauvoo.adapters.driven.google_auth", None)
+        from nauvoo.adapters.driven.google_auth import GoogleAuthAdapter
+
+        yield GoogleAuthAdapter
+
+
+class TestScopeChecking:
+    def test_raises_if_token_missing_scopes(self, mock_google_auth, tmp_path):
+        token_file = tmp_path / "token.json"
+        token_file.write_text(
+            json.dumps({"scopes": ["https://www.googleapis.com/auth/drive.readonly"]})
+        )
+
+        adapter = mock_google_auth(
+            client_secrets_file=tmp_path / "secrets.json",
+            token_file=token_file,
+            scopes=["https://www.googleapis.com/auth/drive"],
+        )
+
+        with pytest.raises(ValueError, match="missing required scopes"):
+            adapter.get_credentials()
+
+    def test_passes_when_all_scopes_present(self, mock_google_auth, tmp_path):
+        token_file = tmp_path / "token.json"
+        token_file.write_text(
+            json.dumps({"scopes": ["https://www.googleapis.com/auth/drive"]})
+        )
+
+        adapter = mock_google_auth(
+            client_secrets_file=tmp_path / "secrets.json",
+            token_file=token_file,
+            scopes=["https://www.googleapis.com/auth/drive"],
+        )
+
+        # Should not raise — scopes match
+        adapter.get_credentials()
+
+    def test_raises_file_not_found_when_no_secrets(self, mock_google_auth, tmp_path):
+        adapter = mock_google_auth(
+            client_secrets_file=tmp_path / "nonexistent_secrets.json",
+            token_file=tmp_path / "nonexistent_token.json",
+            scopes=["https://www.googleapis.com/auth/drive"],
+        )
+
+        with pytest.raises(FileNotFoundError):
+            adapter.get_credentials()

--- a/tests/unit/test_google_drive_writer.py
+++ b/tests/unit/test_google_drive_writer.py
@@ -13,7 +13,7 @@ def _make_adapter() -> GoogleDriveWriterAdapter:
 
 def test_post_reply_calls_api():
     adapter = _make_adapter()
-    replies_mock = adapter._drive.comments.return_value.replies.return_value
+    replies_mock = adapter._drive.replies.return_value
     replies_mock.create.return_value.execute.return_value = {"id": "reply99"}
 
     result = adapter.post_reply(file_id="fileXYZ", comment_id="cmnt1", body="My answer")


### PR DESCRIPTION
## Summary
- Move Nauvoo's default OAuth token path from the shared `~/ObsidianNotes/.../token.json` to `~/.config/nauvoo/token.json` so Nauvoo and Ring Station stop overwriting each other's scopes
- Add scope checking to `GoogleAuthAdapter` — raises `ValueError` with actionable message if token is missing required scopes
- Fix `drive.replies()` API call (was incorrectly chained off `comments()`)
- Add `bin/run-daemon.sh` wrapper for launchd
- Update docs (README, CONTRIBUTING) with new default token path

## Test plan
- [x] Unit tests for scope checking (missing scopes, matching scopes, missing secrets file)
- [x] Unit test for `drive.replies()` fix
- [x] All tests pass via `uv run pytest tests/ -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)